### PR TITLE
handle png and gif icon

### DIFF
--- a/tomoebi.py
+++ b/tomoebi.py
@@ -10,6 +10,7 @@ from PyQt5.QtWidgets import (QApplication, QWidget, QVBoxLayout, QHBoxLayout,
 from PyQt5.QtCore import QTimer, QSize, QByteArray, Qt
 import PyQt5.QtGui
 import twitter
+import glob
 
 class MyWindow(QWidget):
     """main window"""
@@ -190,18 +191,18 @@ class MyWindow(QWidget):
             tweet = self.create_tweet(t)
             tweet_hbox = QHBoxLayout()
             if icon:
-                if not os.path.isfile("images/" + t.user.screen_name + ".jpg"):
+                if not glob.glob("images/" + t.user.screen_name + ".*"):
                     twitter.geticon(t.user.profile_image_url_https, t.user.screen_name)
-                icon = PyQt5.QtGui.QPixmap("images/" + t.user.screen_name + ".jpg")
+                icon = PyQt5.QtGui.QPixmap(glob.glob("images/" + t.user.screen_name + ".*")[0])
                 scaled_icon = icon.scaled(QSize(48, 48), 1, 1)
                 iconviewer = QLabel()
                 iconviewer.setPixmap(scaled_icon)
                 icon_vbox = QVBoxLayout()
                 icon_vbox.addWidget(iconviewer, alignment=Qt.AlignTop)
                 if rtby:
-                    if not os.path.isfile("images/" + rtby[1] + ".jpg"):
+                    if not glob.glob("images/" + rtby[1] + ".*"):
                         twitter.geticon(*rtby)
-                    icon = PyQt5.QtGui.QPixmap("images/" + rtby[1] + ".jpg")
+                    icon = PyQt5.QtGui.QPixmap(glob.glob("images/" + rtby[1] + ".*")[0])
                     scaled_icon = icon.scaled(QSize(24, 24), 1, 1)
                     rticonviewer = QLabel()
                     rticonviewer.setPixmap(scaled_icon)

--- a/twitter.py
+++ b/twitter.py
@@ -4,6 +4,7 @@ import webbrowser
 import json
 import tweepy
 import requests
+import re
 from PyQt5.QtWidgets import QInputDialog
 
 class StreamListener(tweepy.StreamListener):
@@ -88,9 +89,23 @@ def getmyicon(api, screen_name):
 def geticon(url, screen_name):
     response = requests.get(url, allow_redirects=False)
     image = response.content
-    imagename = 'images/' + screen_name + '.jpg'
+    ext = which_ext(image)
+    imagename = 'images/' + screen_name + ext
     with open(imagename, 'wb') as f:
         f.write(image)
+    return imagename
+
+def which_ext(image):
+    '''check image format
+    thanks to http://xaro.hatenablog.jp/entry/2017/05/17/103000'''
+    if re.match(b"^\xff\xd8", image[:2]):
+        return ".jpg"
+    elif re.match(b"^\x89\x50\x4e\x47\x0d\x0a\x1a\x0a", image[:8]):
+        return ".png"
+    elif re.match(b"^\x47\x49\x46\x38", image[:4]):
+        return ".gif"
+    else:
+        print(image)
     
 def get_allimages(api, id):
     status = api.get_status(id)


### PR DESCRIPTION
これまでアイコンは全部無理やりjpgにして保存していたが、そもそもネット上から取得したアイコンはバイナリデータであり、pngやgifを拡張子だけjpgにしても画像のフォーマットは変わっていなかった。そのためアイコンをjpgと決め打ちして保存フォルダから読み込む部分は失敗していた。
このPRでは画像のバイナリデータからフォーマットを確認し、適切な拡張子をつけて保存するようにした。それと同時に保存フォルダから読み込むときもglopを利用してスクリーンネームが一致する画像を拡張子に関係なく検索するようにした。これによってアイコン画像のフォーマットの問題はほぼ解決した。
残る問題点はアニメーションgifを再生できない点である。